### PR TITLE
Sql JSON tests

### DIFF
--- a/snaplets/fay/src/Bead/Domain/Shared/Evaluation.hs
+++ b/snaplets/fay/src/Bead/Domain/Shared/Evaluation.hs
@@ -9,9 +9,12 @@ import Data.Data
 data Result = Passed | Failed
   deriving (Eq, Show, Read, Data, Typeable)
 
-resultCata passed failed r = case r of
-  Passed -> passed
-  Failed -> failed
+resultCata
+  passed
+  failed
+  r = case r of
+    Passed -> passed
+    Failed -> failed
 
 -- Represents the evaluation type for an assignment
 data EvaluationData b p
@@ -50,6 +53,9 @@ data PctConfig = PctConfig { pLimit :: Double }
 
 data Scores a = Scores { unScores :: [a] }
   deriving (Eq, Show, Read, Data, Typeable)
+
+mkScores :: a -> Scores a
+mkScores = Scores . (:[])
 
 data Binary = Binary Result
   deriving (Eq, Show, Read, Data, Typeable)

--- a/src/Bead/Domain/Entities.hs
+++ b/src/Bead/Domain/Entities.hs
@@ -126,7 +126,7 @@ import           Bead.View.Translation
 
 #ifdef TEST
 import           Test.Tasty.Arbitrary
-import           Test.Tasty.TestSet
+import           Test.Tasty.TestSet hiding (shrink)
 #endif
 
 data SubmissionValue
@@ -264,6 +264,16 @@ roleCata
     GroupAdmin  -> groupAdmin
     CourseAdmin -> courseAdmin
     Admin       -> admin
+
+#ifdef TEST
+instance Arbitrary Role where
+  arbitrary = elements roles
+  shrink = roleCata
+    [GroupAdmin, CourseAdmin, Admin]
+    [CourseAdmin, Admin]
+    [Admin]
+    []
+#endif
 
 roles = [Student, GroupAdmin, CourseAdmin, Admin]
 
@@ -404,6 +414,12 @@ newtype TimeZoneName = TimeZoneName { unTzn :: String }
 
 timeZoneName f (TimeZoneName z) = f z
 
+#ifdef TEST
+instance Arbitrary TimeZoneName where
+  arbitrary = TimeZoneName <$> arbitrary
+  shrink = fmap TimeZoneName . timeZoneName shrink
+#endif
+
 showDate :: LocalTime -> String
 showDate = formatTime defaultTimeLocale "%F, %T"
 
@@ -499,6 +515,14 @@ testScriptTypeCata
     TestScriptSimple -> simple
     TestScriptZipped -> zipped
 
+#ifdef TEST
+instance Arbitrary TestScriptType where
+  arbitrary = elements [TestScriptSimple, TestScriptZipped]
+  shrink = testScriptTypeCata
+    [TestScriptZipped]
+    []
+#endif
+
 -- Test Script defines a scripts that can be integrated with the
 -- testing framework for the given course.
 data TestScript = TestScript {
@@ -557,8 +581,14 @@ withFileInfo (FileInfo size date) f = f size date
 -- Applicative functor based FileInfo construction
 fileInfoAppAna size date = FileInfo <$> size <*> date
 
-data Score = Score
+data Score = Score ()
   deriving (Data, Eq, Ord, Read, Show, Typeable)
+
+#ifdef TEST
+instance Arbitrary Score where
+  arbitrary = return (Score ())
+  shrink _ = []
+#endif
 
 -- * PermObjs instance
 

--- a/src/Bead/Domain/Entity/Comment.hs
+++ b/src/Bead/Domain/Entity/Comment.hs
@@ -1,9 +1,14 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 module Bead.Domain.Entity.Comment where
 
 import           Control.Applicative
 import           Data.Data
 import           Data.Time (UTCTime)
+
+#ifdef TEST
+import           Test.Tasty.Arbitrary
+#endif
 
 
 -- Comment type basically indicates that who left the comment,
@@ -25,6 +30,16 @@ commentTypeCata
     CT_GroupAdmin  -> groupAdmin
     CT_CourseAdmin -> courseAdmin
     CT_Admin       -> admin
+
+#ifdef TEST
+instance Arbitrary CommentType where
+  arbitrary = elements [CT_Student, CT_GroupAdmin, CT_CourseAdmin, CT_Admin]
+  shrink = commentTypeCata
+    [CT_GroupAdmin, CT_CourseAdmin, CT_Admin]
+    [CT_CourseAdmin, CT_Admin]
+    [CT_Admin]
+    []
+#endif
 
 -- | Comment on the text of exercise, on the evaluation
 data Comment = Comment {

--- a/src/Bead/Domain/Entity/Feedback.hs
+++ b/src/Bead/Domain/Entity/Feedback.hs
@@ -18,10 +18,11 @@ import           Data.Data
 import           Data.Time (UTCTime(..))
 
 import           Bead.Domain.Func
-import           Bead.Domain.Shared.Evaluation
+import           Bead.Domain.Evaluation
 
 #ifdef TEST
-import           Test.Tasty.TestSet
+import           Test.Tasty.Arbitrary
+import           Test.Tasty.TestSet hiding (shrink)
 #endif
 
 
@@ -51,6 +52,25 @@ feedbackInfo
       MessageForStudent studentComment -> student studentComment
       MessageForAdmin adminComment -> admin adminComment
       Evaluated evalResult evalComment evalAuthor -> evaluated evalResult evalComment evalAuthor
+
+#ifdef TEST
+instance Arbitrary FeedbackInfo where
+  arbitrary = oneof [
+      TestResult <$> arbitrary
+    , MessageForStudent <$> arbitrary
+    , MessageForAdmin <$> arbitrary
+    , Evaluated <$> arbitrary <*> arbitrary <*> arbitrary
+    ]
+  shrink = feedbackInfo
+    (fmap TestResult . shrink)
+    (fmap MessageForStudent . shrink)
+    (fmap MessageForAdmin . shrink)
+    (\evalResult evalComment evalAuthor -> do
+      result <- shrink evalResult
+      comment <- shrink evalComment
+      author <- shrink evalAuthor
+      return $ Evaluated result comment author)
+#endif
 
 -- | Feedback consist of a piece of information and a date when the information
 -- is posted intot the system.

--- a/src/Bead/Persistence/NoSQLDirFile.hs
+++ b/src/Bead/Persistence/NoSQLDirFile.hs
@@ -674,7 +674,7 @@ instance Load Assessment where
     <*> fileLoad d "cfg"  maybeDecodeJSON
 
 instance Load Score where
-  load _d = return Score
+  load _d = return (Score ())
 
 -- * Update instances
 

--- a/src/Bead/Persistence/SQL.hs
+++ b/src/Bead/Persistence/SQL.hs
@@ -43,11 +43,14 @@ import Bead.Persistence.SQL.TestScript
 import Bead.Persistence.SQL.User
 
 #ifdef TEST
+import Bead.Persistence.SQL.JSON (persistJSONConvertTests)
+
 import Test.Tasty.TestSet (TestSet)
 #endif
 
 #ifdef TEST
 tests = do
+  persistJSONConvertTests
   courseAdminTests
   groupTests
   testScriptTests

--- a/src/Bead/Persistence/SQL/Class.hs
+++ b/src/Bead/Persistence/SQL/Class.hs
@@ -301,7 +301,7 @@ instance DomainKey Domain.ScoreKey where
 instance DomainValue Domain.Score where
   type EntityValue Domain.Score = ScoreGeneric
   fromDomainValue _s = Score "score"
-  toDomainValue _ent = Domain.Score
+  toDomainValue _ent = Domain.Score ()
 
 instance DomainKey Domain.NotificationKey where
   type EntityForKey Domain.NotificationKey = NotificationGeneric

--- a/src/Bead/Persistence/SQL/JSON.hs
+++ b/src/Bead/Persistence/SQL/JSON.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 module Bead.Persistence.SQL.JSON where
 
 import           Text.JSON.Generic
@@ -5,6 +6,11 @@ import           Text.JSON.Generic
 import qualified Bead.Domain.Entities as Domain
 import qualified Bead.Domain.Shared.Evaluation as Domain
 import           Bead.Persistence.SQL.Entities (JSONText)
+
+#ifdef TEST
+import           Test.Tasty.Arbitrary
+import           Test.Tasty.TestSet
+#endif
 
 -- * JSON encoding, decoding
 
@@ -61,3 +67,25 @@ encodeScore = encodeJSON
 
 decodeScore :: JSONText -> Domain.Score
 decodeScore = decodeJSON
+
+#ifdef TEST
+persistJSONConvertTests = group "Persistence JSON converters" $ do
+  isInverse "Score" encodeScore decodeScore
+  isInverse "Role" encodeRole decodeRole
+  isInverse "TimeZone" encodeTimeZone decodeTimeZone
+  isInverse "EvalConfig" encodeEvalConfig decodeEvalConfig
+  isInverse "TestScriptType" encodeTestScriptType decodeTestScriptType
+  isInverse "AssignmentType" encodeAssignmentType decodeAssignmentType
+  isInverse "EvaluationResult" encodeEvaluationResult decodeEvaluationResult
+  isInverse "CommentType" encodeCommentType decodeCommentType
+  isInverse "FeedbackInfo " encodeFeedbackInfo decodeFeedbackInfo
+  where
+    isInverse :: (Arbitrary a, Eq a, Show a)
+              => TestName -> (a -> b) -> (b -> a) -> TestSet ()
+    isInverse name encode decode =
+      assertProperty
+        name
+        (\x -> x == (decode $ encode x))
+        arbitrary
+        (concat ["Encode decode of ", name, " is not idempotent"])
+#endif

--- a/src/Bead/Persistence/SQL/Score.hs
+++ b/src/Bead/Persistence/SQL/Score.hs
@@ -116,6 +116,7 @@ scoreTests = do
           -- When
           e  <- saveScoreEvaluation s ev
           es <- evaluationOfScore s
+          -- Then
           equals (Just e) es "An evaluated score does not have some evaluation."
 
     ) (return ())

--- a/src/Bead/Persistence/SQL/TestData.hs
+++ b/src/Bead/Persistence/SQL/TestData.hs
@@ -34,7 +34,7 @@ ev2   = Evaluation (percentageResult 0.01) "escrito"
 
 cmt   = Comment "comment" "User" time CT_Student
 
-scr   = Score
+scr   = Score ()
 
 reg = UserRegistration "username" "email" "name" "token" time
 

--- a/src/Test/Tasty/TestSet.hs
+++ b/src/Test/Tasty/TestSet.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 module Test.Tasty.TestSet (
     TestSet
+  , TestName
   , buildTestTree
   , runTestSet
   , group

--- a/test/Test/Property/EntityGen.hs
+++ b/test/Test/Property/EntityGen.hs
@@ -180,7 +180,7 @@ testFeedbackInfo = oneof
 feedbacks date = Feedback <$> testFeedbackInfo <*> (return date)
 
 scores :: Gen Score
-scores = return Score
+scores = arbitrary
 
 assessments = Assessment <$> manyWords <*> evalConfigs
 


### PR DESCRIPTION
It creates a test suite for encode/decode instances in SQL persistence layer. Arbitrary instances for the necessary objects are provided. The data Score changes as the JSON encoding does not handle empty data constructors. Note: the data Score is a placeholder for further development.