### PR TITLE
Fix/bead admin

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+set -e
+
+cabal clean
+cabal configure --flags "SQLite Tests"
+cabal install --only-dependencies
+cabal test
+
+cabal clean
+cabal configure --flags "-LDAP -SQLite Tests"
+cabal install --only-dependencies
+cabal test


### PR DESCRIPTION
For the email user registration via [BeadAdmin](https://github.com/andorp/bead/blob/080930414bf236561b048be6bdcc131847199c9d/src/AdminMain.hs#L195) needs to have the config loaded from the disk for this reason it is introduced as a parameter for `readUserRegInfo` .