### PR TITLE
Add a Markdown handler

### DIFF
--- a/lang/DictionaryHu.hs
+++ b/lang/DictionaryHu.hs
@@ -442,5 +442,6 @@ dict = DictionaryFile {
     , msg_Domain_EvalPercentage <| "%s%%"
     , msg_SeeMore_SeeMore <| "Kinyit"
     , msg_SeeMore_SeeLess <| "Becsuk"
+    , msg_Markdown_NotFound <| "Sajnos a kért oldal nem található!"
     ]
 }

--- a/src/Bead/View/Markdown.hs
+++ b/src/Bead/View/Markdown.hs
@@ -1,15 +1,28 @@
 module Bead.View.Markdown (
     markdownToHtml
+  , serveMarkdown
   ) where
 
 {- A markdown to HTML conversion. -}
 
-import Data.String.Utils (replace)
-import Text.Pandoc.Options
-import Text.Pandoc.Readers.Markdown (readMarkdown)
-import Text.Pandoc.Writers.HTML (writeHtml)
+import           Control.Monad.IO.Class
+import qualified Data.ByteString.Char8 as BS
+import           Data.String
+import           Data.String.Utils (replace)
+import           System.Directory
+import           System.FilePath
 
-import Text.Blaze.Html5 (Html)
+import           Snap.Core
+import           Text.Pandoc.Options
+import           Text.Pandoc.Readers.Markdown (readMarkdown)
+import           Text.Pandoc.Writers.HTML (writeHtml)
+import           Text.Blaze.Html5
+
+import           Bead.View.BeadContext
+import           Bead.View.ContentHandler
+import           Bead.View.I18N
+import           Bead.View.Pagelets
+import           Bead.View.Translation
 
 -- Produces an HTML value from the given markdown formatted strings what
 -- comes from a text area field, crlf endings must be replaced with lf in the string
@@ -20,3 +33,19 @@ markdownToHtml = writeHtml def' . readMarkdown def . replaceCrlf
 replaceCrlf :: String -> String
 replaceCrlf = replace "\r\n" "\n"
 
+serveMarkdown :: BeadHandler ()
+serveMarkdown = do
+  rq <- getRequest
+  let path = "markdown" </> (BS.unpack $ rqPathInfo rq)
+  exists <- liftIO $ doesFileExist path
+  let render = renderBootstrapPublicPage . publicFrame
+  if exists
+    then do
+      contents <- liftIO $ readFile path
+      render $ return $ markdownToHtml contents
+    else do
+      render $ do
+        msg <- getI18N
+        return $ do
+          p $ fromString . msg $
+            msg_Markdown_NotFound "Sorry, but the requested page could not be found."

--- a/src/Bead/View/RouteOf.hs
+++ b/src/Bead/View/RouteOf.hs
@@ -26,6 +26,7 @@ module Bead.View.RouteOf (
   , newTestScriptPath
   , modifyTestScriptPath
   , uploadFilePath
+  , markdownPath
   , submissionDetailsPath
   , administrationPath
   , groupRegistrationPath
@@ -124,6 +125,9 @@ modifyTestScriptPath = "/modify-test-script"
 
 uploadFilePath :: RoutePath
 uploadFilePath = "/upload-file"
+
+markdownPath :: RoutePath
+markdownPath = "/markdown"
 
 submissionDetailsPath :: RoutePath
 submissionDetailsPath = "/submission-details"

--- a/src/Bead/View/Routing.hs
+++ b/src/Bead/View/Routing.hs
@@ -37,6 +37,7 @@ import           Bead.View.Content.All
 import           Bead.View.ErrorPage
 import           Bead.View.Login as L
 import           Bead.View.LoggedInFilter
+import           Bead.View.Markdown
 #ifndef LDAPEnabled
 import           Bead.View.Registration
 import           Bead.View.ResetPassword
@@ -67,6 +68,7 @@ routes config = join
     , Command.routeHandler Command.ping
     , ("/upload", fileUpload)
     ]
+  , [ (markdownPath, serveMarkdown) ]
     -- Add static handlers
   , [ ("",          serveDirectory "static") ]
   ]

--- a/src/Bead/View/Translation/Base.hs
+++ b/src/Bead/View/Translation/Base.hs
@@ -505,4 +505,6 @@ labels =
 
  , "msg_SeeMore_SeeMore"
  , "msg_SeeMore_SeeLess"
+
+ , "msg_Markdown_NotFound"
  ]


### PR DESCRIPTION
This handler makes it possible to place pure Markdown files under the `markdown` directory and serve them as HTML pages under the `/markdown/` link.  However, note that the pages cannot be standalone, but they will be displayed in frames with the global Bootstrap header.  It is mostly recommended for public information pages or documentation whose source could also be maintained in the Git repository, in easily editable Markdown format.