### PR TITLE
Make it possible to patch the default (built-in) language messages.

### DIFF
--- a/src/Bead/View/BeadContext.hs
+++ b/src/Bead/View/BeadContext.hs
@@ -97,7 +97,8 @@ dictionarySnaplet d l = makeSnapContext
   ((addDefault d), l)
   where
     -- The source code contains english comments by default
-    addDefault = Map.insert (Language "en") (idDictionary, DictionaryInfo "en.ico" "English")
+    addDefault = Map.insertWith (\_new old -> old) (Language defaultLanguage)
+      (idDictionary, defaultDictionaryInfo)
 
 -- A dictionary infos is a list that contains the language of and information
 -- about the dictionaries contained by the DictionarySnaplet

--- a/src/Bead/View/Dictionary.hs
+++ b/src/Bead/View/Dictionary.hs
@@ -16,6 +16,9 @@ module Bead.View.Dictionary (
   , dictionaryFileToInfo -- Reads out the icon file name
   , idDictionary
   , (<|)
+  , defaultLanguage
+  , defaultDictionary
+  , defaultDictionaryInfo
   ) where
 
 -- Haskell imports
@@ -76,6 +79,20 @@ dictionaryFileCata f (DictionaryFile iconFile langCode langName entries) =
 
 (<|) :: (String -> Translation String) -> String -> Translation String
 (<|) = ($)
+
+defaultLanguage = "en"
+
+defaultDictionaryInfo = DictionaryInfo {
+    icon         = "en.ico"
+  , languageName = "English"
+  }
+
+defaultDictionary = DictionaryFile {
+    iconFile = icon defaultDictionaryInfo
+  , langCode = defaultLanguage
+  , langName = languageName defaultDictionaryInfo
+  , entries  = []
+  }
 
 -- Creates a new dictionary from the entries of the dictionary file,
 -- if no translation key is found in the entries, the original value


### PR DESCRIPTION
It turned out that the current implementation does not let the user to load
dictionaries or dictionary patches for the language (which is currently "en")
that is implictly contained in the sources.  This limitation is now removed,
and a `defaultDictionary` constant is exported from `Bead.View.Dictionary`
that could be referenced as the parent for the respective patches.