### PR TITLE
Expand size of text fields in SQL to avoid unintentional cut-offs.

### DIFF
--- a/src/Bead/Persistence/SQL/Entities.hs
+++ b/src/Bead/Persistence/SQL/Entities.hs
@@ -40,7 +40,7 @@ Assessment
 
 Assignment
   name        Text
-  description Text
+  description Text sqltype="longtext character set utf8"
   type        JSONText
   start       UTCTime
   end         UTCTime
@@ -49,7 +49,7 @@ Assignment
   deriving Show
 
 Comment
-  text   Text
+  text   Text sqltype="longtext character set utf8"
   author Text
   date   UTCTime
   type   JSONText
@@ -62,12 +62,12 @@ Course
   deriving Show
 
 Evaluation
-  result  JSONText
-  written Text
+  result  JSONText sqltype="longtext character set utf8"
+  written Text     sqltype="longtext character set utf8"
   deriving Show
 
 Feedback
-  info JSONText
+  info JSONText sqltype="longtext character set utf8"
   date UTCTime
   deriving Show
 
@@ -77,7 +77,7 @@ Group
   deriving Show
 
 Notification
-  message     Text
+  message     Text sqltype="longtext character set utf8"
   deriving Show
 
 Score
@@ -85,7 +85,7 @@ Score
   deriving Show
 
 Submission
-  simple   Text       Maybe
+  simple   Text       Maybe sqltype="longtext character set utf8"
   zipped   ByteString Maybe sqltype=longblob
   postDate UTCTime
   deriving Show
@@ -93,7 +93,7 @@ Submission
 TestCase
   name         Text
   description  Text
-  simpleValue  Text       Maybe
+  simpleValue  Text       Maybe sqltype="longtext character set utf8"
   zippedValue  ByteString Maybe sqltype=longblob
   info         Text
   deriving Show
@@ -101,8 +101,8 @@ TestCase
 TestScript
   name        Text
   description Text
-  notes       Text
-  script      Text
+  notes       Text sqltype="longtext character set utf8"
+  script      Text sqltype="longtext character set utf8"
   testScriptType JSONText
   deriving Show
 


### PR DESCRIPTION
Unfortunately, the default "text" fields in MySQL can only be of size 2^16 (that is, 64 KB) at maximum, which appears to be quite small for certain fields stored in the database.  Thus they are now changed to "longtext" so they could range up to 2^32, which should be enough for a while.  Note that the Unicode character setting has to be also added because `persistent-mysql` does not know anything about longtexts (at the moment).
