### PR TITLE
Add option to BeadAdmin for importing users from LDAP directly.

### DIFF
--- a/src/Bead/Domain/Entities.hs
+++ b/src/Bead/Domain/Entities.hs
@@ -424,11 +424,11 @@ showDate :: LocalTime -> String
 showDate = formatTime defaultTimeLocale "%F, %T"
 
 -- UserRegInfo is a User Registration Info that consists of
--- a Username, a Password, an Email Address, a Full Name, and a time zone
-newtype UserRegInfo = UserRegInfo (String, String, String, String, TimeZoneName)
+-- a Username, a User ID, a Password, an Email Address, a Full Name, and a time zone
+newtype UserRegInfo = UserRegInfo (String, String, String, String, String, TimeZoneName)
 
-userRegInfoCata f (UserRegInfo (username, password, email, fullName, timeZoneName))
-  = f username password email fullName timeZoneName
+userRegInfoCata f (UserRegInfo (username, uid, password, email, fullName, timeZoneName))
+  = f username uid password email fullName timeZoneName
 
 -- The language what the dictionary represents.
 newtype Language = Language String

--- a/src/Bead/View/Registration.hs
+++ b/src/Bead/View/Registration.hs
@@ -86,7 +86,7 @@ changeUserPassword userdb username password = do
 
 createUserWithRole :: Bead.View.Content.Role -> Persist.Interpreter -> FilePath -> UserRegInfo -> IO ()
 createUserWithRole role persist usersdb = userRegInfoCata $
-  \name password email fullName timeZone ->
+  \name uid password email fullName timeZone ->
     let usr = User {
         u_role = role
       , u_username = Username name
@@ -94,7 +94,7 @@ createUserWithRole role persist usersdb = userRegInfoCata $
       , u_name = fullName
       , u_timezone = timeZone
       , u_language = Language "hu" -- TODO: I18N
-      , u_uid = Uid name
+      , u_uid = Uid uid
       }
     in createUser persist usersdb usr password
 


### PR DESCRIPTION
This change also comes with following the separation of usernames and user identifiers.  So BeadAdmin will prompt the user for user identifier on creating new ones.
