### PR TITLE
MySQL test runner

### DIFF
--- a/Bead.cabal
+++ b/Bead.cabal
@@ -69,7 +69,6 @@ Library
     CPP-Options: -DMYSQL
 
     Build-Depends:
-      persistent-sqlite >= 2.2 && < 2.3,
       persistent-mysql >= 2.3 && < 2.4,
       persistent-template >= 2.1 && < 2.2,
       resourcet
@@ -87,6 +86,7 @@ Library
       Bead.Persistence.SQL.FileSystem
       Bead.Persistence.SQL.Group
       Bead.Persistence.SQL.MySQL
+      Bead.Persistence.SQL.MySQLTestRunner
       Bead.Persistence.SQL.JSON
       Bead.Persistence.SQL.Notification
       Bead.Persistence.SQL.Registration
@@ -161,7 +161,6 @@ Library
     old-locale == 1.0.0.6,
     pandoc >=1.14 && <1.16,
     persistent >=2.2 && <2.3,
-    persistent-sqlite >=2.2 && <2.3,
     persistent-mysql >=2.3 && <2.4,
     persistent-template >=2.1 && <2.2,
     pqueue >=1.2.0 && <2.0,
@@ -339,7 +338,6 @@ test-suite BeadTest
   if flag(MySQL)
     CPP-Options: -DTEST -DMYSQL
     Build-Depends:
-      persistent-sqlite >=2.2 && <2.3,
       persistent-mysql >=2.3 && <2.4,
       persistent-template >=2.1 && <2.2,
       resourcet

--- a/src/Bead/Persistence/SQL/Assessment.hs
+++ b/src/Bead/Persistence/SQL/Assessment.hs
@@ -19,7 +19,7 @@ import qualified Data.Set as Set
 
 import           Bead.Persistence.SQL.Course
 import           Bead.Persistence.SQL.Group
-
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.TestData
 
 import           Test.Tasty.TestSet (ioTest, shrink, equals)
@@ -89,37 +89,33 @@ assessmentsOfGroup key = do
 #ifdef TEST
 
 assessmentTests = do
-  shrink "Assessment end-to-end story"
-    (do ioTest "Assessment end-to-end test" $ runSql $ do
-          initDB
-          c  <- saveCourse course
-          g  <- saveGroup c group
-          ca <- saveCourseAssessment c ast
-          ga <- saveGroupAssessment g ast
+  ioTest "Assessment end-to-end test" $ runSql $ do
+    c  <- saveCourse course
+    g  <- saveGroup c group
+    ca <- saveCourseAssessment c ast
+    ga <- saveGroupAssessment g ast
 
-          cast' <- loadAssessment ca
-          equals ast cast' "The saved and loaded course assessnment were different."
-          cca <- courseOfAssessment ca
-          equals (Just c) cca "The course assessment has no appropiate course"
-          cga <- groupOfAssessment ca
-          equals Nothing cga "The course assessment had a group"
-          modifyAssessment ca ast2
-          cast2 <- loadAssessment ca
-          equals ast2 cast2 "The course assessment modification has failed"
+    cast' <- loadAssessment ca
+    equals ast cast' "The saved and loaded course assessnment were different."
+    cca <- courseOfAssessment ca
+    equals (Just c) cca "The course assessment has no appropiate course"
+    cga <- groupOfAssessment ca
+    equals Nothing cga "The course assessment had a group"
+    modifyAssessment ca ast2
+    cast2 <- loadAssessment ca
+    equals ast2 cast2 "The course assessment modification has failed"
 
-          gast' <- loadAssessment ga
-          equals ast gast' "The saved and loaded group assessnment were different."
-          cga <- courseOfAssessment ga
-          equals Nothing cga "The group assessment had course"
-          gga <- groupOfAssessment ga
-          equals (Just g) gga "The group assessment had no group"
-          modifyAssessment ga ast2
-          gast2 <- loadAssessment ga
-          equals ast2 gast2 "The course assessment modification has failed"
-    ) (return ())
+    gast' <- loadAssessment ga
+    equals ast gast' "The saved and loaded group assessnment were different."
+    cga <- courseOfAssessment ga
+    equals Nothing cga "The group assessment had course"
+    gga <- groupOfAssessment ga
+    equals (Just g) gga "The group assessment had no group"
+    modifyAssessment ga ast2
+    gast2 <- loadAssessment ga
+    equals ast2 gast2 "The course assessment modification has failed"
 
   ioTest "List course assessments" $ runSql $ do
-    initDB
     c  <- saveCourse course
     as <- assessmentsOfCourse c
     equals [] as "The course had some assessment after the creation"
@@ -135,7 +131,6 @@ assessmentTests = do
       (Set.fromList as) "The course had different assessment set"
 
   ioTest "List group assessments" $ runSql $ do
-    initDB
     c  <- saveCourse course
     g  <- saveGroup c group
     as <- assessmentsOfGroup g

--- a/src/Bead/Persistence/SQL/Assignment.hs
+++ b/src/Bead/Persistence/SQL/Assignment.hs
@@ -22,7 +22,7 @@ import qualified Data.Set as Set
 
 import           Bead.Persistence.SQL.Course
 import           Bead.Persistence.SQL.Group
-
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.TestData
 
 import           Test.Tasty.TestSet (ioTest, shrink, equals)
@@ -159,7 +159,6 @@ testCaseOfAssignment key = do
 assignmentTests = do
   shrink "Assignment end-to-end story"
     (do ioTest "Assignment end-to-end test" $ runSql $ do
-          initDB
           c  <- saveCourse course
           g  <- saveGroup c group
           ca <- saveCourseAssignment c asg
@@ -192,7 +191,6 @@ assignmentTests = do
           equals t1 t2 "The creation time of the group assignment has changed"
     )
     (do ioTest "Save and load course assignment" $ runSql $ do
-          initDB
           c  <- saveCourse course
           ca <- saveCourseAssignment c asg
           casg' <- loadAssignment ca
@@ -202,7 +200,6 @@ assignmentTests = do
           cga <- groupOfAssignment ca
           equals Nothing cga "The course assignment had a group"
         ioTest "Save and load group assignment" $ runSql $ do
-          initDB
           c  <- saveCourse course
           g  <- saveGroup c group
           ga <- saveGroupAssignment g asg
@@ -213,7 +210,6 @@ assignmentTests = do
           cga <- groupOfAssignment ga
           equals (Just g) cga "The group assignment had no appropiate group"
         ioTest "Modify course assignment" $ runSql $ do
-          initDB
           c  <- saveCourse course
           ca <- saveCourseAssignment c asg
           t1 <- assignmentCreatedTime ca
@@ -223,7 +219,6 @@ assignmentTests = do
           equals asg2 asg' "The modification of the course assignment has failed"
           equals t1 t2 "The creation time of the course assignment has changed"
         ioTest "Modify group assignment" $ runSql $ do
-          initDB
           c  <- saveCourse course
           g  <- saveGroup c group
           ga <- saveGroupAssignment g asg
@@ -236,7 +231,6 @@ assignmentTests = do
     )
 
   ioTest "List course assignments" $ runSql $ do
-    initDB
     c  <- saveCourse course
     as <- courseAssignments c
     equals [] as "The course had some assignment after the creation"
@@ -252,7 +246,6 @@ assignmentTests = do
       (Set.fromList as) "The course had different assignment set"
 
   ioTest "List group assignments" $ runSql $ do
-    initDB
     c  <- saveCourse course
     g  <- saveGroup c group
     as <- groupAssignments g

--- a/src/Bead/Persistence/SQL/Comment.hs
+++ b/src/Bead/Persistence/SQL/Comment.hs
@@ -18,8 +18,8 @@ import           Data.String (fromString)
 import           Bead.Persistence.SQL.Assignment
 import           Bead.Persistence.SQL.Course
 import           Bead.Persistence.SQL.Submission
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.User
-
 import           Bead.Persistence.SQL.TestData
 
 import           Test.Tasty.TestSet (ioTest, shrink, equals)
@@ -54,36 +54,32 @@ submissionOfComment key = do
 
 #ifdef TEST
 commentTests = do
-  shrink "Comment end-to-end story."
-    (do ioTest "Comment end-to-end test" $ runSql $ do
-          initDB
-          c  <- saveCourse course
-          ca <- saveCourseAssignment c asg
-          saveUser user1
-          s  <- saveSubmission ca user1name sbm
-          cs <- commentsOfSubmission s
-          equals
-            (Set.fromList [])
-            (Set.fromList cs)
-            "Comments were for an empty submission."
-          cm <- saveComment s cmt
-          cs <- commentsOfSubmission s
-          equals
-            (Set.fromList [cm])
-            (Set.fromList cs)
-            "Saved comment was not found for the submission."
-          cmt' <- loadComment cm
-          equals cmt cmt' "The comment was not saved and loaded correctly"
-          sc <- submissionOfComment cm
-          equals s sc "The submission of the comment was wrong"
-          cm2 <- saveComment s cmt
-          cs <- commentsOfSubmission s
-          equals
-            (Set.fromList [cm,cm2])
-            (Set.fromList cs)
-            "Comments of the submission were wrong."
-        return ())
-    (do return ())
-  return ()
+  ioTest "Comment end-to-end test" $ runSql $ do
+    c  <- saveCourse course
+    ca <- saveCourseAssignment c asg
+    saveUser user1
+    s  <- saveSubmission ca user1name sbm
+    cs <- commentsOfSubmission s
+    equals
+      (Set.fromList [])
+      (Set.fromList cs)
+      "Comments were for an empty submission."
+    cm <- saveComment s cmt
+    cs <- commentsOfSubmission s
+    equals
+      (Set.fromList [cm])
+      (Set.fromList cs)
+      "Saved comment was not found for the submission."
+    cmt' <- loadComment cm
+    equals cmt cmt' "The comment was not saved and loaded correctly"
+    sc <- submissionOfComment cm
+    equals s sc "The submission of the comment was wrong"
+    cm2 <- saveComment s cmt
+    cs <- commentsOfSubmission s
+    equals
+      (Set.fromList [cm,cm2])
+      (Set.fromList cs)
+      "Comments of the submission were wrong."
+
 #endif
 

--- a/src/Bead/Persistence/SQL/Course.hs
+++ b/src/Bead/Persistence/SQL/Course.hs
@@ -16,6 +16,7 @@ import           Bead.Persistence.SQL.User
 #ifdef TEST
 import           Control.Monad.IO.Class (liftIO)
 
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.TestData
 
 import           Test.Tasty.TestSet (ioTest, equals, satisfies)
@@ -98,7 +99,6 @@ courseAdmins key = do
 
 courseAdminTests = do
   ioTest "Create Course Admin for the course" $ runSql $ do
-    initDB
     saveUser user1
     c <- saveCourse course
     acs <- administratedCourses user1name
@@ -111,13 +111,11 @@ courseAdminTests = do
     equals [c] (map fst acs) "The administrated course list was wrong."
 
   ioTest "No Course Admin for the course" $ runSql $ do
-    initDB
     c <- saveCourse course
     us <- courseAdmins c
     equals [] us "Some admin was found for the course."
 
   ioTest "Same user is created as admin twice" $ runSql $ do
-    initDB
     saveUser user1
     c <- saveCourse course
     let u1 = Domain.u_username user1
@@ -127,7 +125,6 @@ courseAdminTests = do
     equals [u1] us "Admins of course were different."
 
   ioTest "Two different users administrates the same course" $ runSql $ do
-    initDB
     saveUser user1
     saveUser user2
     c <- saveCourse course

--- a/src/Bead/Persistence/SQL/Entities.hs
+++ b/src/Bead/Persistence/SQL/Entities.hs
@@ -1,4 +1,3 @@
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE EmptyDataDecls #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE GADTs #-}
@@ -23,10 +22,6 @@ import           Database.Persist.Sql
 import           Database.Persist.TH
 
 import qualified Bead.Domain.Entities as Domain
-
-#ifdef TEST
-import           Database.Persist.Sqlite
-#endif
 
 -- String represents a JSON value
 type JSONText = String
@@ -348,15 +343,3 @@ withUser username nothing just =
 
 userKey username =
   fmap (fmap entityKey) $ getBy (UniqueUsername $ Domain.usernameCata Text.pack username)
-
-#ifdef TEST
-
--- * Test helpers
-
-runSql :: Persist a -> IO a
-runSql = runSqlite ":memory:"
-
-initDB :: Persist ()
-initDB = void $ runMigrationSilent migrateAll
-
-#endif

--- a/src/Bead/Persistence/SQL/Evaluation.hs
+++ b/src/Bead/Persistence/SQL/Evaluation.hs
@@ -18,6 +18,7 @@ import           Bead.Persistence.SQL.JSON
 import           Bead.Persistence.SQL.Assignment
 import           Bead.Persistence.SQL.Course
 import           Bead.Persistence.SQL.Submission
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.User
 
 import           Bead.Persistence.SQL.TestData
@@ -77,26 +78,22 @@ scoreOfEvaluation key = do
 #ifdef TEST
 
 evaluationTests = do
-  shrink "Evaluation end-to-end story"
-    (do ioTest "Evaluation end-to-end story" $ runSql $ do
-          initDB
-          c  <- saveCourse course
-          ca <- saveCourseAssignment c asg
-          saveUser user1
-          s  <- saveSubmission ca user1name sbm
-          se1 <- evaluationOfSubmission s
-          equals Nothing se1 "Found some evaluation for a non evaluated submission."
-          e  <- saveSubmissionEvaluation s ev
-          ev' <- loadEvaluation e
-          equals ev ev' "Saved and load evaluation are differents."
-          s2 <- submissionOfEvaluation e
-          equals (Just s) s2 "Submission of the evaluation is not calculated correctly."
-          se2 <- evaluationOfSubmission s
-          equals (Just e) se2 "Found some evaluation for a non evaluated submission."
-          modifyEvaluation e ev2
-          ev2' <- loadEvaluation e
-          equals ev2 ev2' "The modified evaluation was not read out correctly.")
-    (return ()) -- TODO: Shrinked tests
-  return ()
+  ioTest "Evaluation end-to-end story" $ runSql $ do
+    c  <- saveCourse course
+    ca <- saveCourseAssignment c asg
+    saveUser user1
+    s  <- saveSubmission ca user1name sbm
+    se1 <- evaluationOfSubmission s
+    equals Nothing se1 "Found some evaluation for a non evaluated submission."
+    e  <- saveSubmissionEvaluation s ev
+    ev' <- loadEvaluation e
+    equals ev ev' "Saved and load evaluation are differents."
+    s2 <- submissionOfEvaluation e
+    equals (Just s) s2 "Submission of the evaluation is not calculated correctly."
+    se2 <- evaluationOfSubmission s
+    equals (Just e) se2 "Found some evaluation for a non evaluated submission."
+    modifyEvaluation e ev2
+    ev2' <- loadEvaluation e
+    equals ev2 ev2' "The modified evaluation was not read out correctly."
 
 #endif

--- a/src/Bead/Persistence/SQL/Feedback.hs
+++ b/src/Bead/Persistence/SQL/Feedback.hs
@@ -17,6 +17,7 @@ import qualified Data.Set as Set
 import           Bead.Persistence.SQL.Assignment
 import           Bead.Persistence.SQL.Course
 import           Bead.Persistence.SQL.Submission
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.User
 
 import           Bead.Persistence.SQL.TestData
@@ -53,45 +54,40 @@ submissionOfFeedback key = do
 
 #ifdef TEST
 feedbackTests = do
-  shrink "Feedback end-to-end story."
-    (do ioTest "Feedback end-to-end test" $ runSql $ do
-          initDB
-          c  <- saveCourse course
-          ca <- saveCourseAssignment c asg
-          saveUser user1
-          s  <- saveSubmission ca user1name sbm
-          fs <- feedbacksOfSubmission s
-          equals
-            (Set.fromList [])
-            (Set.fromList fs)
-            "Feedbacks were for an empty submission."
+  ioTest "Feedback end-to-end test" $ runSql $ do
+    c  <- saveCourse course
+    ca <- saveCourseAssignment c asg
+    saveUser user1
+    s  <- saveSubmission ca user1name sbm
+    fs <- feedbacksOfSubmission s
+    equals
+      (Set.fromList [])
+      (Set.fromList fs)
+      "Feedbacks were for an empty submission."
 
-          let saveFb s f = do fm <- saveFeedback s f
-                              f' <- loadFeedback fm
-                              equals f f' "The feedback was not saved and loaded correctly"
-                              return fm
+    let saveFb s f = do fm <- saveFeedback s f
+                        f' <- loadFeedback fm
+                        equals f f' "The feedback was not saved and loaded correctly"
+                        return fm
 
-          fm <- saveFb s fbTestResult
-          fs <- feedbacksOfSubmission s
-          equals
-            (Set.fromList [fm])
-            (Set.fromList fs)
-            "Saved feedback was not found for the submission."
-          fc <- submissionOfFeedback fm
-          equals s fc "The submission of the feedback was wrong"
+    fm <- saveFb s fbTestResult
+    fs <- feedbacksOfSubmission s
+    equals
+      (Set.fromList [fm])
+      (Set.fromList fs)
+      "Saved feedback was not found for the submission."
+    fc <- submissionOfFeedback fm
+    equals s fc "The submission of the feedback was wrong"
 
-          fm2 <- saveFb s fbMsgStudent
-          fs <- feedbacksOfSubmission s
-          equals
-            (Set.fromList [fm,fm2])
-            (Set.fromList fs)
-            "Feedbacks of the submission were wrong."
+    fm2 <- saveFb s fbMsgStudent
+    fs <- feedbacksOfSubmission s
+    equals
+      (Set.fromList [fm,fm2])
+      (Set.fromList fs)
+      "Feedbacks of the submission were wrong."
 
-          saveFb s fbMsgForAdmin
-          saveFb s fbEvaluated
+    saveFb s fbMsgForAdmin
+    saveFb s fbEvaluated
 
-        return ())
-    (do return ())
-  return ()
 #endif
 

--- a/src/Bead/Persistence/SQL/FileSystem.hs
+++ b/src/Bead/Persistence/SQL/FileSystem.hs
@@ -100,7 +100,9 @@ initFS = liftIO $ mapM_ createDirWhenDoesNotExist fsDirs
       unless existDir . createDirectory $ d
 
 removeFS :: (MonadIO io) => io ()
-removeFS = liftIO $ removeDirectoryRecursive datadir
+removeFS = liftIO $ do
+  exists <- doesDirectoryExist datadir
+  when exists $ removeDirectoryRecursive datadir
 
 isSetUpFS :: (MonadIO io) => io Bool
 isSetUpFS = liftIO . fmap and $ mapM doesDirectoryExist fsDirs

--- a/src/Bead/Persistence/SQL/Group.hs
+++ b/src/Bead/Persistence/SQL/Group.hs
@@ -18,7 +18,7 @@ import qualified Data.Set as Set
 
 import           Bead.Persistence.SQL.Course
 import           Bead.Persistence.SQL.User
-
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.TestData
 
 import           Test.Tasty.TestSet (ioTest, equals)
@@ -95,21 +95,18 @@ unsubscribe username courseDomKey groupDomKey = withUser username (return ()) $ 
 
 groupTests = do
   ioTest "Create and load group" $ runSql $ do
-    initDB
     c <- saveCourse course
     g <- saveGroup  c group
     group' <- loadGroup g
     equals group group' "Group was saved and load incorrectly"
 
   ioTest "Course key of group was saved correctly" $ runSql $ do
-    initDB
     c <- saveCourse course
     g <- saveGroup  c group
     c' <- courseOfGroup g
     equals c c' "Course key was not loaded correctly"
 
   ioTest "Check group subscription" $ runSql $ do
-    initDB
     saveUser user1
     c <- saveCourse course
     g <- saveGroup  c group
@@ -122,7 +119,6 @@ groupTests = do
     equals True ingr "User was not in the subscribed group"
 
   ioTest "Check creating group admins" $ runSql $ do
-    initDB
     saveUser user1
     saveUser user2
     c <- saveCourse course
@@ -144,7 +140,6 @@ groupTests = do
       "The admins were different to the group"
 
   ioTest "Check the user subscription and unsubscription from the course" $ runSql $ do
-    initDB
     saveUser user1
     saveUser user2
     c <- saveCourse course

--- a/src/Bead/Persistence/SQL/MySQLTestRunner.hs
+++ b/src/Bead/Persistence/SQL/MySQLTestRunner.hs
@@ -1,0 +1,48 @@
+{-# LANGUAGE CPP #-}
+module Bead.Persistence.SQL.MySQLTestRunner where
+
+import Bead.Persistence.Initialization
+import Bead.Persistence.SQL.Entities (Persist)
+import Bead.Persistence.SQL.MySQL
+
+#ifdef TEST
+import Data.IORef
+import System.IO.Unsafe
+#endif
+
+#ifdef TEST
+
+runPersist = runInterpreter
+
+-- TODO: FIX this dirty hack to instatiate only once the persistent layer
+persistRef :: IORef Interpreter
+persistRef = unsafePerformIO $ newIORef undefined
+
+createInterpreter :: IO ()
+createInterpreter = do
+  interp <- createPersistInterpreter defaultConfig
+  writeIORef persistRef interp
+
+getPersistInterpreter :: IO Interpreter
+getPersistInterpreter = readIORef persistRef
+
+runPersistIOCmd :: Persist a -> IO a
+runPersistIOCmd m = do
+  interp <- getPersistInterpreter
+  x <- runPersist interp m
+  case x of
+    Left msg -> fail msg -- >> return undefined
+    Right x  -> return x
+
+runSql :: Persist a -> IO a
+runSql p = do
+  createInterpreter
+  reinitPersistence
+  runPersistIOCmd $ do
+    p
+
+reinitPersistence = do
+  init <- createPersistInit defaultConfig
+  tearDown init
+  initPersist init
+#endif

--- a/src/Bead/Persistence/SQL/Registration.hs
+++ b/src/Bead/Persistence/SQL/Registration.hs
@@ -9,6 +9,7 @@ import           Bead.Persistence.SQL.Class
 import           Bead.Persistence.SQL.Entities
 
 #ifdef TEST
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.TestData
 
 import           Test.Tasty.TestSet (ioTest, equals)
@@ -36,7 +37,6 @@ loadUserReg key = do
 
 userRegistrationTests = do
   ioTest "Save and load user registration" $ runSql $ do
-    initDB
     k <- saveUserReg reg
     reg' <- loadUserReg k
     equals reg reg' "User registration was saved and load incorrectly."

--- a/src/Bead/Persistence/SQL/Score.hs
+++ b/src/Bead/Persistence/SQL/Score.hs
@@ -20,6 +20,7 @@ import           Bead.Persistence.SQL.Entities
 import           Bead.Persistence.SQL.Assessment
 import           Bead.Persistence.SQL.Course
 import           Bead.Persistence.SQL.Evaluation
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.User
 
 import           Bead.Persistence.SQL.TestData
@@ -87,37 +88,37 @@ scoresOfUser user = do
 
 #ifdef TEST
 scoreTests = do
-  shrink "Score end-to-end story"
-    (do ioTest "Score end-to-end test" $ runSql $ do
-          -- Given
-          initDB
-          saveUser user1
-          c  <- saveCourse course
-          ca <- saveCourseAssessment c ast
+  ioTest "Score end-to-end test" $ runSql $ do
+    -- Given
+    saveUser user1
+    c  <- saveCourse course
+    ca <- saveCourseAssessment c ast
+    scs <- scoresOfUser user1name
+    equals [] scs "There were scores registered for unscored user."
 
-          scs <- scoresOfUser user1name
-          equals [] scs "There were scores registered for unscored user."
+    -- When
+    s  <- saveScore user1name ca scr
 
-          -- When
-          s  <- saveScore user1name ca scr
-          -- Then
-          sa <- assessmentOfScore s
-          equals ca sa "The assessment of the score was different."
-          -- Then
-          us <- usernameOfScore s
-          equals user1name us "The username of the score was different."
-          -- Then
-          es <- evaluationOfScore s
-          equals Nothing es "A non evaluated score has some evaluation."
-          -- Then
-          scs <- scoresOfUser user1name
-          equals [s] scs "There wasn't score for the scored user."
+    -- Then
+    sa <- assessmentOfScore s
+    equals ca sa "The assessment of the score was different."
 
-          -- When
-          e  <- saveScoreEvaluation s ev
-          es <- evaluationOfScore s
-          -- Then
-          equals (Just e) es "An evaluated score does not have some evaluation."
+    -- Then
+    us <- usernameOfScore s
+    equals user1name us "The username of the score was different."
 
-    ) (return ())
+    -- Then
+    es <- evaluationOfScore s
+    equals Nothing es "A non evaluated score has some evaluation."
+
+    -- Then
+    scs <- scoresOfUser user1name
+    equals [s] scs "There wasn't score for the scored user."
+
+    -- When
+    e  <- saveScoreEvaluation s ev
+    es <- evaluationOfScore s
+
+    -- Then
+    equals (Just e) es "An evaluated score does not have some evaluation."
 #endif

--- a/src/Bead/Persistence/SQL/Submission.hs
+++ b/src/Bead/Persistence/SQL/Submission.hs
@@ -24,7 +24,7 @@ import           Data.String (fromString)
 import           Bead.Persistence.SQL.Assignment
 import           Bead.Persistence.SQL.Course
 import           Bead.Persistence.SQL.User
-
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.TestData
 
 import           Test.Tasty.TestSet (ioTest, shrink, equals)
@@ -176,7 +176,6 @@ usersOpenedSubmissions key username =
 submissionTests = do
   shrink "Submission end-to-end story."
     (do ioTest "Submission end-to-end test case" $ runSql $ do
-          initDB
           c  <- saveCourse course
           ca <- saveCourseAssignment c asg
           saveUser user1
@@ -239,13 +238,11 @@ submissionTests = do
             "The opened submission returned wrong set after removing one opened submissions for user1"
           return ())
     (do ioTest "Save and load submission" $ runSql $ do
-          initDB
           c  <- saveCourse course
           ca <- saveCourseAssignment c asg
           saveUser user1
           s  <- saveSubmission ca user1name sbm
           sbm' <- loadSubmission s
           equals sbm sbm' "Saved and loaded submission were different.")
-  return ()
 
 #endif

--- a/src/Bead/Persistence/SQL/TestCase.hs
+++ b/src/Bead/Persistence/SQL/TestCase.hs
@@ -20,7 +20,7 @@ import           Bead.Persistence.SQL.JSON
 import           Bead.Persistence.SQL.Assignment
 import           Bead.Persistence.SQL.Course
 import           Bead.Persistence.SQL.TestScript
-
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.TestData
 
 import           Test.Tasty.TestSet (ioTest, shrink, equals)
@@ -106,32 +106,26 @@ modifyTestScriptOfTestCase caseKey scriptKey = void $ do
 #ifdef TEST
 
 testCaseTests = do
-  shrink "Test Case end-to-end story."
-    (do ioTest "Test Case end-to-end case" $ runSql $ do
-          initDB
-          c  <- saveCourse course
-          ts <- saveTestScript c script
-          a  <- saveCourseAssignment c asg
-          tc <- saveTestCase ts a case1
-          case1' <- loadTestCase tc
-          equals case1 case1' "Saved and load test cases were different"
-          a' <- assignmentOfTestCase tc
-          equals a a' "Assignment of the test case was wrong"
-          ts' <- testScriptOfTestCase tc
-          equals ts ts' "Test script of the test case was wrong"
-          modifyTestCase tc case2
-          case2' <- loadTestCase tc
-          equals case2 case2' "Test case was not modified correctly"
-          ts2 <- saveTestScript c script2
-          modifyTestScriptOfTestCase tc ts2
-          ts3 <- testScriptOfTestCase tc
-          equals ts2 ts3 "Test script of the test case did not get modified"
-          removeTestCaseAssignment tc a
-          tc2 <- testCaseOfAssignment a
-          equals Nothing tc2 "Test case of the assignment was wrong"
-
-          return ())
-    (do return ()) -- TODO
-  return ()
+  ioTest "Test Case end-to-end case" $ runSql $ do
+    c  <- saveCourse course
+    ts <- saveTestScript c script
+    a  <- saveCourseAssignment c asg
+    tc <- saveTestCase ts a case1
+    case1' <- loadTestCase tc
+    equals case1 case1' "Saved and load test cases were different"
+    a' <- assignmentOfTestCase tc
+    equals a a' "Assignment of the test case was wrong"
+    ts' <- testScriptOfTestCase tc
+    equals ts ts' "Test script of the test case was wrong"
+    modifyTestCase tc case2
+    case2' <- loadTestCase tc
+    equals case2 case2' "Test case was not modified correctly"
+    ts2 <- saveTestScript c script2
+    modifyTestScriptOfTestCase tc ts2
+    ts3 <- testScriptOfTestCase tc
+    equals ts2 ts3 "Test script of the test case did not get modified"
+    removeTestCaseAssignment tc a
+    tc2 <- testCaseOfAssignment a
+    equals Nothing tc2 "Test case of the assignment was wrong"
 
 #endif

--- a/src/Bead/Persistence/SQL/TestData.hs
+++ b/src/Bead/Persistence/SQL/TestData.hs
@@ -9,7 +9,7 @@ course  = Course "name" "desc" TestScriptSimple
 
 group   = Group "name" "desc"
 
-time    = read "2014-06-09 12:55:27.959203 UTC"
+time    = read "2014-06-09 12:55:27 UTC"
 
 sbm     = Submission (SimpleSubmission "submission") time
 sbm2    = Submission (ZippedSubmission "submission2") time

--- a/src/Bead/Persistence/SQL/TestScript.hs
+++ b/src/Bead/Persistence/SQL/TestScript.hs
@@ -13,7 +13,7 @@ import           Bead.Persistence.SQL.JSON
 
 #ifdef TEST
 import           Bead.Persistence.SQL.Course
-
+import           Bead.Persistence.SQL.MySQLTestRunner
 import           Bead.Persistence.SQL.TestData
 
 import           Test.Tasty.TestSet (ioTest, shrink, equals)
@@ -63,7 +63,6 @@ modifyTestScript key script = do
 testScriptTests = do
   shrink "Test Script end-to-end story."
     (do ioTest "Test Script end-to-end test" $ runSql $ do
-          initDB
           c <- saveCourse course
           t <- saveTestScript c script
           script' <- loadTestScript t
@@ -76,19 +75,16 @@ testScriptTests = do
     )
 
     (do ioTest "Save and load test script" $ runSql $ do
-          initDB
           c <- saveCourse course
           t <- saveTestScript c script
           script' <- loadTestScript t
           equals script script' "The scripts were differents."
         ioTest "Course of the test script" $ runSql $ do
-          initDB
           c <- saveCourse course
           t <- saveTestScript c script
           c' <- courseOfTestScript t
           equals c c' "The course keys were differents."
         ioTest "Modify the test script" $ runSql $ do
-          initDB
           c <- saveCourse course
           t <- saveTestScript c script
           modifyTestScript t script2

--- a/test/Test/Unit/Persistence.hs
+++ b/test/Test/Unit/Persistence.hs
@@ -140,7 +140,7 @@ testOpenSubmissions = testCase "Users separated correctly in open submission tab
         , u_language = Language "hu"
         , u_uid = usernameCata Uid otherStudent
         }
-      admin = Username "admin"
+      admin = Username "admin2"
       adminUser = User {
           u_role = Admin
         , u_username = admin


### PR DESCRIPTION
 * Removes the `Sqlite` dependency, which was used only in testing and hide some errors because of the differences between `MySQL` and `SQLite`. As there is a docker image which contains an installed and configured MySQL, which can run all the test cases.
 * In the `src/Bead/Persistence/SQL/MySQL.hs` a workaround was introduced to avoid altering the database on every start.