### PR TITLE
[Fix] Handle missing percentage evaluation gracefully

### DIFF
--- a/src/Bead/View/Content.hs
+++ b/src/Bead/View/Content.hs
@@ -3,6 +3,7 @@
 module Bead.View.Content (
     blaze
   , getParameter
+  , getParameterWithDefault
   , getParameterValues
   , getOptionalParameter
   , getOptionalOrNonEmptyParameter

--- a/src/Bead/View/Content/Evaluation/Page.hs
+++ b/src/Bead/View/Content/Evaluation/Page.hs
@@ -90,7 +90,7 @@ abstractEvaluationPostHandler getEvKeyParameter evCommand = do
     evConfigCata
       (getJSONParam (fieldName evaluationResultField) "No evaluation can be found.")
       (\_ -> do
-        percentage  <- getParameter evaluationPercentagePrm
+        percentage  <- getParameterWithDefault 0 evaluationPercentagePrm
         commentOnly <- getParameter evaluationCommentOnlyPrm
         return $
           if commentOnly
@@ -172,7 +172,8 @@ evaluationFrame evConfig msg content = do
                ]
            Bootstrap.colMd4 $
              H.input ! A.name (fieldName evaluationPercentagePrm) ! A.type_ "number"
-                     ! A.min (fromString $ show 0) ! A.max (fromString $ show 100))
+                     ! A.min (fromString $ show 0) ! A.max (fromString $ show 100)
+                     ! A.value (fromString $ show 0))
     (do Bootstrap.optionalTextInput (fieldName freeFormEvaluationParam) (msg $ msg_Evaluation_FreeFormEvaluation "Evaluation") ""
         H.p . fromString $ printf (msg $ msg_Evaluation_FreeForm_Information $ unwords
           [ "Note that this text will be used everywhere as the evaluation itself.  Hence it is recommended to keep"

--- a/src/Bead/View/ContentHandler.hs
+++ b/src/Bead/View/ContentHandler.hs
@@ -6,6 +6,7 @@ module Bead.View.ContentHandler (
   , userStory
   , registrationStory
   , getParameter
+  , getParameterWithDefault
   , getParameterValues -- Calculates a list of values for the given parameter
   , getParameterOrError
   , getOptionalParameter -- Calculates the value of the given parameter if it is defined
@@ -232,6 +233,16 @@ getParameter param = do
   maybe
     (throwError . strMsg $ notFound param) -- TODO: I18N
     (decodeParamValue param)
+    reqParam
+
+getParameterWithDefault :: a -> Parameter a -> ContentHandler' b a
+getParameterWithDefault defValue param = do
+  reqParam <- getParam . B.pack . name $ param
+  maybe
+    (throwError . strMsg $ notFound param) -- TODO: I18N
+    (\bs -> if (B.null bs)
+              then return defValue
+              else (decodeParamValue param bs))
     reqParam
 
 -- Calculates a list of values named and decoded by the given parameter


### PR DESCRIPTION
The server crashes if the user forgets to fill in the value of the percentage on the evaluation page.  That is because the initial value of the corresponding input field is the empty string that cannot be parsed as a number.  The changes in the commit attempt to fix this by introducing a new combinator for handling POST parameters that could return some meaningful (type-specific) default value on empty input.


