### PR TITLE
Migrate to Stack

### DIFF
--- a/Bead.cabal
+++ b/Bead.cabal
@@ -195,7 +195,7 @@ Library
       Bead.View.Content.SetUserPassword.Page
       Bead.View.EmailTemplate
       Bead.View.ResetPassword
-
+                    
   Build-Depends:
     aeson >=0.8 && <0.9,
     async >=2.0,

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,70 @@
+flags:
+  pandoc:
+    old-locale: true
+    network-uri: false
+  QuickCheck:
+    base4point8: false
+  transformers-compat:
+    three: true
+
+extra-package-dbs: []
+packages:
+- '.'
+extra-deps:
+- JuicyPixels-3.2.7.2
+- QuickCheck-2.8.2
+- adjunctions-4.2.2
+- base-orphans-0.5.4
+- bifunctors-5.2
+- blaze-html-0.8.1.2
+- blaze-markup-0.7.1.0
+- bytestring-builder-0.10.8.1.0
+- cmark-0.4.1
+- comonad-4.2.7.2
+- conduit-extra-1.1.13.2
+- cpphs-1.19.3
+- either-4.4.1.1
+- fast-logger-2.4.6
+- fay-0.23.1.8
+- fay-base-0.20.0.1
+- fay-jquery-0.6.1.0
+- fay-text-0.3.2.2
+- free-4.12.4
+- heist-0.14.1.4
+- highlighting-kate-0.6.2.1
+- http-api-data-0.2.4
+- json-0.9.1
+- kan-extensions-4.2.3
+- lens-4.12.3
+- mime-mail-0.4.9
+- monad-logger-0.3.19
+- mtl-compat-0.2.1.1
+- network-uri-2.6.1.0
+- optparse-applicative-0.12.1.0
+- pandoc-1.15.2.1
+- pandoc-types-1.12.4.7
+- persistent-2.2.4.1
+- persistent-mysql-2.3.0.2
+- persistent-template-2.1.3.6
+- profunctors-5.2
+- random-1.1
+- reflection-2
+- semigroupoids-5.0.1
+- snap-0.14.0.7
+- snap-blaze-0.2.1.3
+- snap-core-0.9.8.0
+- snaplet-fay-0.3.3.13
+- streaming-commons-0.1.15.5
+- syb-0.5.1
+- texmath-0.8.6.5
+- text-1.2.2.1
+- time-locale-compat-0.1.1.3
+- timezone-olson-0.1.7
+- timezone-series-0.1.5.1
+- transformers-compat-0.4.0.4
+- unix-time-0.3.6
+- utf8-string-1.0.1.1
+- vector-0.11.0.0
+- vector-algorithms-0.7.0.1
+- zip-archive-0.2.3.7
+resolver: lts-0.7


### PR DESCRIPTION
Bead can now be built using stack. First install stack, then run `stack setup` to download ghc if necessary. The project can then be built using `stack build` and run using `stack exec Bead`.

Flags (like Tests, MySQL, SSO) can be passed as follows: `stack build --flag Bead:Tests`

Not yet done: migrate start-ghci, start-ghci-nosql, ... to use stack ghci